### PR TITLE
fix infinite loop in ie8

### DIFF
--- a/jquery.sglide.js
+++ b/jquery.sglide.js
@@ -422,6 +422,12 @@ version:	2.1.2
 					var increment = w / (snaps - 1);
 					var snapValues = [0];
 					var step = increment;
+
+					//on some browsers knob.width = 0 which makes increment 0 and creates an infinite loop
+					if (increment < 1) {
+						increment = 1
+					} 
+
 					while (step <= w+2){	// added 2px to fix glitch when drawing last mark at 7 or 8 snaps (accounts for decimal)
 						snapValues.push(step);
 						step += increment;

--- a/sGlide.js
+++ b/sGlide.js
@@ -541,7 +541,7 @@ function sGlide(self, options){
 			var snapValues = [0];
 			var step = increment;
 
-			//on some browsers know.width = 0 which makes increment 0 and creates an infinite loop
+			//on some browsers knob.width = 0 which makes increment 0 and creates an infinite loop
 			if (increment < 1) {
 				increment = 1
 			} 

--- a/sGlide.js
+++ b/sGlide.js
@@ -540,6 +540,12 @@ function sGlide(self, options){
 			var increment = w / (snaps - 1);
 			var snapValues = [0];
 			var step = increment;
+
+			//on some browsers know.width = 0 which makes increment 0 and creates an infinite loop
+			if (increment < 1) {
+				increment = 1
+			} 
+
 			while (step <= w+2){	// added 2px to fix glitch when drawing last mark at 7 or 8 snaps (accounts for decimal)
 				snapValues.push(step);
 				step += increment;


### PR DESCRIPTION
Using webshims (http://afarkas.github.io/webshim/demos/), sGlide works in ie8 but the user gets an error that a script is running too long.  This is caused by an infinite loop due to the width of the image not being available.   This fixes that.  
