### PR TITLE
add sGlide.ready event

### DIFF
--- a/jquery.sglide.js
+++ b/jquery.sglide.js
@@ -916,6 +916,7 @@ version:	2.1.2
 					self.sGlide('startAt', num);
 
 					$(el).off('makeready.'+guid, setStartAt);
+					$(el).trigger('sGlide.ready')
 				};
 
 				// Listen for image loaded


### PR DESCRIPTION
There are times when you need to know that sGlide is fully setup.  Since a few things don't happen until images are loaded, there is no way to know.  I added a sGlide.ready event that you can listen for.  I only added it in the jQuery version.
